### PR TITLE
Composer home path owner

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,9 +13,8 @@ composer_global_packages: []
 
 composer_add_to_path: true
 
-
-composer_home_path_owner: "{{ default(omit) }}"
-composer_home_path_group: "{{ default(omit) }}"
+composer_home_path_owner: "root"
+composer_home_path_group: "root"
 
 # GitHub OAuth token (used to help overcome API rate limits).
 composer_github_oauth_token: ''

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,8 +13,8 @@ composer_global_packages: []
 
 composer_add_to_path: true
 
-composer_home_path_owner: "root"
-composer_home_path_group: "root"
+composer_home_owner: "root"
+composer_home_group: "root"
 
 # GitHub OAuth token (used to help overcome API rate limits).
 composer_github_oauth_token: ''

--- a/tasks/global-require.yml
+++ b/tasks/global-require.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install configured globally-required packages.
   sudo: yes
-  sudo_user: "{{ composer_home_path_owner }}"
+  sudo_user: "{{ composer_home_owner }}"
   shell: >
     COMPOSER_HOME={{ composer_home_path }}
     composer global require {{ item.name }}:{{ item.release | default('@stable') }} --no-progress

--- a/tasks/global-require.yml
+++ b/tasks/global-require.yml
@@ -1,5 +1,7 @@
 ---
 - name: Install configured globally-required packages.
+  sudo: yes
+  sudo_user: "{{ composer_home_path_owner }}"
   shell: >
     COMPOSER_HOME={{ composer_home_path }}
     composer global require {{ item.name }}:{{ item.release | default('@stable') }} --no-progress

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,16 +26,16 @@
 - name: Ensure composer directory exists.
   file:
     path: "{{ composer_home_path }}"
-    owner: "{{ composer_home_path_owner }}"
-    group: "{{ composer_home_path_group }}"
+    owner: "{{ composer_home_owner }}"
+    group: "{{ composer_home_group }}"
     state: directory
 
 - name: Add GitHub OAuth token for Composer (if configured).
   template:
     src: "auth.json.j2"
     dest: "{{ composer_home_path }}/auth.json"
-    owner: "{{ composer_home_path_owner }}"
-    group: "{{ composer_home_path_group }}"
+    owner: "{{ composer_home_owner }}"
+    group: "{{ composer_home_group }}"
   when: composer_github_oauth_token != ''
 
 - include: global-require.yml


### PR DESCRIPTION
I noticed PR#9 was failing ( https://github.com/geerlingguy/ansible-role-composer/pull/9 ) 

Updated to set the default ownership as root.  Then we can override as needed.

Also set to install global packages as composer_home_path_owner.

thanks,

Joe
